### PR TITLE
feat: reverse swipe navigation logic in calendar and lunar modal

### DIFF
--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -139,11 +139,11 @@ export const Calendar: React.FC<CalendarProps> = ({ onDateSelect, refreshTrigger
     const isRightSwipe = distance < -50;
 
     if (isLeftSwipe) {
-      // Swipe left - go to next month (forwards in time)
-      handleNextMonth();
-    } else if (isRightSwipe) {
-      // Swipe right - go to previous month (backwards in time)
+      // Swipe left - go to previous month (backwards in time)
       handlePrevMonth();
+    } else if (isRightSwipe) {
+      // Swipe right - go to next month (forwards in time)
+      handleNextMonth();
     }
   };
 

--- a/src/components/Modals/LunarModal.tsx
+++ b/src/components/Modals/LunarModal.tsx
@@ -336,11 +336,11 @@ export const LunarModal: React.FC<LunarModalProps> = ({
     const isRightSwipe = distance < -50;
 
     if (isLeftSwipe) {
-      // Swipe left - go to next day (forwards in time)
-      handleNextDay();
-    } else if (isRightSwipe) {
-      // Swipe right - go to previous day (backwards in time)
+      // Swipe left - go to previous day (backwards in time)
       handlePrevDay();
+    } else if (isRightSwipe) {
+      // Swipe right - go to next day (forwards in time)
+      handleNextDay();
     }
   };
 


### PR DESCRIPTION
- Calendar: swipe left now goes to previous month, swipe right to next month
- LunarModal: swipe left now goes to previous day, swipe right to next day
- Reverses the previous swipe behavior for more intuitive navigation