### PR TITLE
Fix: Ensure consistent moon age calculation

### DIFF
--- a/src/services/lunarService.ts
+++ b/src/services/lunarService.ts
@@ -332,6 +332,7 @@ export function getCurrentMoonInfo(): {
   formattedIllumination: string;
 } {
   const now = new Date();
+  now.setHours(0, 0, 0, 0);
   const phaseData = getMoonPhaseData(now);
   const phase = getLunarPhase(now);
 


### PR DESCRIPTION
The moon age displayed on the landing page and in the lunar modal was inconsistent due to a difference in the time of day used for the calculation. The `CurrentMoonInfo` component used the current time, while the `LunarModal` used the beginning of the selected day.

This commit resolves the discrepancy by modifying the `getCurrentMoonInfo` function in `lunarService.ts` to set the time to the start of the day (midnight) before performing the moon age calculation. This ensures that both components use a consistent time, providing a uniform moon age across the application.